### PR TITLE
new job distribution containers for component and service image states

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - backend
 
   api:
-    image: nuvla/api:4.2.2
+    image: nuvla/api:4.2.3
     environment:
       - ES_HOST=es
       - ES_PORT=9200
@@ -82,7 +82,7 @@ services:
   # User interface takes the paths /, /ui/*, anything else
   # is routed elsewhere.
   ui:
-    image: nuvla/ui:2.4.2
+    image: nuvla/ui:2.4.3
     deploy:
       labels:
         - "traefik.enable=true"
@@ -98,7 +98,7 @@ services:
       - frontend
 
   job-executor:
-    image: nuvla/job:2.3.4
+    image: nuvla/job:2.3.5
     entrypoint: /app/job_executor.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --es-hosts es
     deploy:
@@ -108,8 +108,8 @@ services:
     networks:
       - backend
 
-  job-dist-jobs-cleanup:
-    image: nuvla/job:2.3.4
+  jobd-jobs-cleanup:
+    image: nuvla/job:2.3.5
     entrypoint: /app/job_distributor_jobs_cleanup.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181
     deploy:
@@ -119,10 +119,32 @@ services:
     networks:
       - backend
 
-  job-dist-deployment-state:
-    image: nuvla/job:2.3.4
+  jobd-deployment-state:
+    image: nuvla/job:2.3.5
     entrypoint: /app/job_distributor_deployment_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 10
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+    networks:
+      - backend
+
+  jobd-comp-image-state:
+    image: nuvla/job:2.3.5
+    entrypoint: /app/job_distributor_component_image_state.py
+    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+    networks:
+      - backend
+
+  jobd-srvc-image-state:
+    image: nuvla/job:2.3.5
+    entrypoint: /app/job_distributor_service_image_state.py
+    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600
     deploy:
       restart_policy:
         condition: on-failure

--- a/prod/core/docker-compose.yml
+++ b/prod/core/docker-compose.yml
@@ -14,7 +14,7 @@ secrets:
 
 services:
   api:
-    image: nuvla/api:4.2.2
+    image: nuvla/api:4.2.3
     environment:
       - ES_HOST=es
       - ES_PORT=9200
@@ -46,7 +46,7 @@ services:
   # User interface takes the paths /, /ui/*, anything else
   # is routed elsewhere.
   ui:
-    image: nuvla/ui:2.4.2
+    image: nuvla/ui:2.4.3
     deploy:
       placement:
         constraints:
@@ -65,7 +65,7 @@ services:
       - traefik-public
 
   job-executor:
-    image: nuvla/job:2.3.4
+    image: nuvla/job:2.3.5
     entrypoint: /app/job_executor.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --es-hosts es
     deploy:
@@ -78,8 +78,8 @@ services:
     networks:
       - nuvla-backend
 
-  job-dist-jobs-cleanup:
-    image: nuvla/job:2.3.4
+  jobd-jobs-cleanup:
+    image: nuvla/job:2.3.5
     entrypoint: /app/job_distributor_jobs_cleanup.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181
     deploy:
@@ -92,10 +92,32 @@ services:
     networks:
       - nuvla-backend
 
-  job-dist-deployment-state:
-    image: nuvla/job:2.3.4
+  jobd-deployment-state:
+    image: nuvla/job:2.3.5
     entrypoint: /app/job_distributor_deployment_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 10
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+    networks:
+      - nuvla-backend
+
+  jobd-comp-image-state:
+    image: nuvla/job:2.3.5
+    entrypoint: /app/job_distributor_component_image_state.py
+    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+    networks:
+      - nuvla-backend
+
+  jobd-srvc-image-state:
+    image: nuvla/job:2.3.5
+    entrypoint: /app/job_distributor_service_image_state.py
+    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600
     deploy:
       restart_policy:
         condition: on-failure

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -107,7 +107,7 @@ services:
     networks:
       - test-net
 
-  job-dist-jobs-cleanup:
+  jobd-jobs-cleanup:
     image: nuvladev/job:master
     entrypoint: /app/job_distributor_jobs_cleanup.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181
@@ -118,7 +118,7 @@ services:
     networks:
       - test-net
 
-  job-dist-deployment-state:
+  jobd-deployment-state:
     image: nuvladev/job:master
     entrypoint: /app/job_distributor_deployment_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 10
@@ -129,7 +129,7 @@ services:
     networks:
       - test-net
 
-  job-dist-component-image-state:
+  jobd-comp-image-state:
     image: nuvladev/job:master
     entrypoint: /app/job_distributor_component_image_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600
@@ -140,7 +140,7 @@ services:
     networks:
       - test-net
 
-  job-dist-service-image-state:
+  jobd-srvc-image-state:
     image: nuvladev/job:master
     entrypoint: /app/job_distributor_service_image_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -129,6 +129,28 @@ services:
     networks:
       - test-net
 
+  job-dist-component-image-state:
+    image: nuvladev/job:master
+    entrypoint: /app/job_distributor_component_image_state.py
+    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+    networks:
+      - backend
+
+  job-dist-service-image-state:
+    image: nuvladev/job:master
+    entrypoint: /app/job_distributor_service_image_state.py
+    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+    networks:
+      - backend
+
 configs:
   traefik.toml:
     file: ./traefik/traefik.toml

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - test-net
 
   api:
-    image: nuvladev/api:new-image-callbacks
+    image: nuvladev/api:master
     environment:
       - ES_HOST=es
       - ES_PORT=9200
@@ -97,7 +97,7 @@ services:
       - test-net
 
   job-executor:
-    image: nuvladev/job:new-image-update
+    image: nuvladev/job:master
     entrypoint: /app/job_executor.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --es-hosts es
     deploy:
@@ -108,7 +108,7 @@ services:
       - test-net
 
   job-dist-jobs-cleanup:
-    image: nuvladev/job:new-image-update
+    image: nuvladev/job:master
     entrypoint: /app/job_distributor_jobs_cleanup.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181
     deploy:
@@ -119,7 +119,7 @@ services:
       - test-net
 
   job-dist-deployment-state:
-    image: nuvladev/job:new-image-update
+    image: nuvladev/job:master
     entrypoint: /app/job_distributor_deployment_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 10
     deploy:
@@ -130,26 +130,26 @@ services:
       - test-net
 
   job-dist-component-image-state:
-    image: nuvladev/job:new-image-update
+    image: nuvladev/job:master
     entrypoint: /app/job_distributor_component_image_state.py
-    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600
+    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 60
     deploy:
       restart_policy:
         condition: on-failure
         delay: 5s
     networks:
-      - backend
+      - test-net
 
   job-dist-service-image-state:
-    image: nuvladev/job:new-image-update
+    image: nuvladev/job:master
     entrypoint: /app/job_distributor_service_image_state.py
-    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600
+    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 60
     deploy:
       restart_policy:
         condition: on-failure
         delay: 5s
     networks:
-      - backend
+      - test-net
 
 configs:
   traefik.toml:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - test-net
 
   api:
-    image: nuvladev/api:master
+    image: nuvladev/api:new-image-callbacks
     environment:
       - ES_HOST=es
       - ES_PORT=9200
@@ -97,7 +97,7 @@ services:
       - test-net
 
   job-executor:
-    image: nuvladev/job:master
+    image: nuvladev/job:new-image-update
     entrypoint: /app/job_executor.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --es-hosts es
     deploy:
@@ -108,7 +108,7 @@ services:
       - test-net
 
   job-dist-jobs-cleanup:
-    image: nuvladev/job:master
+    image: nuvladev/job:new-image-update
     entrypoint: /app/job_distributor_jobs_cleanup.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181
     deploy:
@@ -119,7 +119,7 @@ services:
       - test-net
 
   job-dist-deployment-state:
-    image: nuvladev/job:master
+    image: nuvladev/job:new-image-update
     entrypoint: /app/job_distributor_deployment_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 10
     deploy:
@@ -130,7 +130,7 @@ services:
       - test-net
 
   job-dist-component-image-state:
-    image: nuvladev/job:master
+    image: nuvladev/job:new-image-update
     entrypoint: /app/job_distributor_component_image_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600
     deploy:
@@ -141,7 +141,7 @@ services:
       - backend
 
   job-dist-service-image-state:
-    image: nuvladev/job:master
+    image: nuvladev/job:new-image-update
     entrypoint: /app/job_distributor_service_image_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600
     deploy:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -132,7 +132,7 @@ services:
   job-dist-component-image-state:
     image: nuvladev/job:master
     entrypoint: /app/job_distributor_component_image_state.py
-    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 60
+    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600
     deploy:
       restart_policy:
         condition: on-failure
@@ -143,7 +143,7 @@ services:
   job-dist-service-image-state:
     image: nuvladev/job:master
     entrypoint: /app/job_distributor_service_image_state.py
-    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 60
+    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600
     deploy:
       restart_policy:
         condition: on-failure


### PR DESCRIPTION
When validated, `job-dist-component-image-state` and `job-dist-service-image-state` services should be propagated to `demo/` and `prod/` deployment compose files.

Connected to https://github.com/nuvla/job-engine/pull/58 and https://github.com/nuvla/api-server/pull/249

For validation from master, merge after the above PR are merged.