### PR TITLE
healthcheck on api-server

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -78,6 +78,10 @@ services:
     networks:
       - backend
       - frontend
+    healthcheck:
+      start_period: 30s
+      retries: 5
+      test: wget --spider http://localhost:8201/api/cloud-entry-point && wget --spider http://localhost:8201/api/user-template/email-password || exit 1
 
   # User interface takes the paths /, /ui/*, anything else
   # is routed elsewhere.

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.7'
 
 services:
   proxy:
@@ -81,7 +81,7 @@ services:
     healthcheck:
       start_period: 30s
       retries: 5
-      test: wget --spider http://localhost:8201/api/cloud-entry-point && wget --spider http://localhost:8201/api/user-template/email-password || exit 1
+      test: curl -sSf http://localhost:8200/api/cloud-entry-point || exit 1
 
   # User interface takes the paths /, /ui/*, anything else
   # is routed elsewhere.


### PR DESCRIPTION
Ask docker to run `healthcheck:` on api-server before declaring the container is running. curl is provided by `ring` image.
Requires release of ring and then release of api-server to use new ring image.