### PR TITLE
ES_ENDPOINTS instead of ES_HOST/PORT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - pip install nuvla-api
   - python -c 'import nuvla.api;'
 script:
-  - $TRAVIS_BUILD_DIR/test/swarm-deploy.sh deploy $SWARM_SIZE && ip=`cat $HOME/nuvla-test-host` && $TRAVIS_BUILD_DIR/test/wait-avail.sh https://$ip/api/cloud-entry-point $WAIT_AVAIL_MIN || exit 1
+  - $TRAVIS_BUILD_DIR/test/swarm-deploy.sh deploy $SWARM_SIZE && ip=`cat $HOME/nuvla-test-host` && $TRAVIS_BUILD_DIR/test/wait-avail.sh https://$ip/api/cloud-entry-point $WAIT_AVAIL_MIN
   - cd functional-tests && export EXAMPLES_ROOT=${HOME} && export NUVLA_INSECURE=TRUE && export NUVLA_HOST=`cat $HOME/nuvla-test-host` && export SSH_PUBLIC_KEY=$HOME/.ssh/id_rsa.pub && export mname=`cat $HOME/docker-machine-master` && eval $($HOME/docker-machine env $mname) && printenv && lein do clean, test
 after_success:
   - $TRAVIS_BUILD_DIR/test/swarm-deploy.sh terminate

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - pip install nuvla-api
   - python -c 'import nuvla.api;'
 script:
-  - $TRAVIS_BUILD_DIR/test/swarm-deploy.sh deploy $SWARM_SIZE && ip=`cat $HOME/nuvla-test-host` && $TRAVIS_BUILD_DIR/test/wait-avail.sh https://$ip/api/cloud-entry-point $WAIT_AVAIL_MIN
+  - $TRAVIS_BUILD_DIR/test/swarm-deploy.sh deploy $SWARM_SIZE && ip=`cat $HOME/nuvla-test-host` && $TRAVIS_BUILD_DIR/test/wait-avail.sh https://$ip/api/cloud-entry-point $WAIT_AVAIL_MIN || exit 1
   - cd functional-tests && export EXAMPLES_ROOT=${HOME} && export NUVLA_INSECURE=TRUE && export NUVLA_HOST=`cat $HOME/nuvla-test-host` && export SSH_PUBLIC_KEY=$HOME/.ssh/id_rsa.pub && export mname=`cat $HOME/docker-machine-master` && eval $($HOME/docker-machine env $mname) && printenv && lein do clean, test
 after_success:
   - $TRAVIS_BUILD_DIR/test/swarm-deploy.sh terminate

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - pip install nuvla-api
   - python -c 'import nuvla.api;'
 script:
-  - $TRAVIS_BUILD_DIR/test/swarm-deploy.sh deploy $SWARM_SIZE && ip=`cat $HOME/nuvla-test-host` && $TRAVIS_BUILD_DIR/test/wait-avail.sh https://$ip/api/cloud-entry-point $WAIT_AVAIL_MIN
+  - $TRAVIS_BUILD_DIR/test/swarm-deploy.sh deploy $SWARM_SIZE && ip=`cat $HOME/nuvla-test-host` && $TRAVIS_BUILD_DIR/test/wait-avail.sh https://$ip/api/cloud-entry-point $WAIT_AVAIL_MIN || { >&2 echo "failed to provision Nuvla."; $TRAVIS_BUILD_DIR/test/swarm-deploy.sh terminate; exit 1; }
   - cd functional-tests && export EXAMPLES_ROOT=${HOME} && export NUVLA_INSECURE=TRUE && export NUVLA_HOST=`cat $HOME/nuvla-test-host` && export SSH_PUBLIC_KEY=$HOME/.ssh/id_rsa.pub && export mname=`cat $HOME/docker-machine-master` && eval $($HOME/docker-machine env $mname) && printenv && lein do clean, test
 after_success:
   - $TRAVIS_BUILD_DIR/test/swarm-deploy.sh terminate

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -60,8 +60,7 @@ services:
   api:
     image: nuvla/api:4.2.5
     environment:
-      - ES_HOST=es
-      - ES_PORT=9200
+      - ES_ENDPOINTS=es
       - ZK_ENDPOINTS=zk:2181
       - NUVLA_SUPER_PASSWORD=supeR8-supeR8
     deploy:

--- a/prod/core/docker-compose.yml
+++ b/prod/core/docker-compose.yml
@@ -16,8 +16,7 @@ services:
   api:
     image: nuvla/api:4.2.5
     environment:
-      - ES_HOST=es
-      - ES_PORT=9200
+      - ES_ENDPOINTS=es
       - ZK_ENDPOINTS=zk:2181
       - NUVLA_SUPER_PASSWORD=supeR8-supeR8
     secrets:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -60,8 +60,7 @@ services:
   api:
     image: nuvladev/api:master
     environment:
-      - ES_HOST=es
-      - ES_PORT=9200
+      - ES_ENDPOINTS=es
       - ZK_ENDPOINTS=zk:2181
       - NUVLA_SUPER_PASSWORD=${NUVLA_SUPER_PASSWORD:-supeR8-supeR8}
     deploy:


### PR DESCRIPTION
`ES_ENDPOINTS=host1[:port][,host2[:port],...]`. Where on the right-hand side either a list of hostnames/IPs (with optional ports; with 9200 as default) of the ES nodes, or a global DNS name possibly resolving to multiple IPs (e.g. in Docker compose: multiple service defs with common value in `net-alias` in the predefined subnet).