### PR TITLE
add two deployment schedulers for deployment state check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 
+### Changed
+
   - Deployment state job was split into two for "new" and "old" deployments with
     10 and 60 seconds check intervals respectively. This was done to reduce
-    unnecessary load on the server and remote COEs.
+    unnecessary load on the server and remote COEs. This resulted in two services
+    jobd-deployment-state_10 and jobd-deployment-state_60 in the compose files.
 
 ## [2.2.0] - 2020-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+  - Deployment state job was split into two for "new" and "old" deployments with
+    10 and 60 seconds check intervals respectively. This was done to reduce
+    unnecessary load on the server and remote COEs.
+
 ## [2.2.0] - 2020-07-06
 
 This release update nuvla components to following versions:

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -123,7 +123,7 @@ services:
       - backend
 
   jobd-deployment-state_10:
-    image: nuvladev/job:2.4.0
+    image: nuvla/job:2.4.0
     entrypoint: /app/job_distributor_deployment_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 10
     deploy:
@@ -134,7 +134,7 @@ services:
       - backend
 
   jobd-deployment-state_60:
-    image: nuvladev/job:2.4.0
+    image: nuvla/job:2.4.0
     entrypoint: /app/job_distributor_deployment_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 60
     deploy:

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -122,10 +122,21 @@ services:
     networks:
       - backend
 
-  jobd-deployment-state:
-    image: nuvla/job:2.4.0
+  jobd-deployment-state_10:
+    image: nuvladev/job:2.4.0
     entrypoint: /app/job_distributor_deployment_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 10
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+    networks:
+      - backend
+
+  jobd-deployment-state_60:
+    image: nuvladev/job:2.4.0
+    entrypoint: /app/job_distributor_deployment_state.py
+    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 60
     deploy:
       restart_policy:
         condition: on-failure

--- a/prod/core/docker-compose.yml
+++ b/prod/core/docker-compose.yml
@@ -91,10 +91,21 @@ services:
     networks:
       - nuvla-backend
 
-  jobd-deployment-state:
-    image: nuvla/job:2.3.16
+  jobd-deployment-state_10:
+    image: nuvladev/job:2.4.0
     entrypoint: /app/job_distributor_deployment_state.py
-    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 10
+    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 10 --statsd ${STATSD_HOST:-graphite}
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+    networks:
+      - nuvla-backend
+
+  jobd-deployment-state_60:
+    image: nuvladev/job:2.4.0
+    entrypoint: /app/job_distributor_deployment_state.py
+    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 60 --statsd ${STATSD_HOST:-graphite}
     deploy:
       restart_policy:
         condition: on-failure

--- a/prod/core/docker-compose.yml
+++ b/prod/core/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - nuvla-backend
 
   jobd-deployment-state_10:
-    image: nuvladev/job:2.4.0
+    image: nuvla/job:2.4.0
     entrypoint: /app/job_distributor_deployment_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 10 --statsd ${STATSD_HOST:-graphite}
     deploy:
@@ -103,7 +103,7 @@ services:
       - nuvla-backend
 
   jobd-deployment-state_60:
-    image: nuvladev/job:2.4.0
+    image: nuvla/job:2.4.0
     entrypoint: /app/job_distributor_deployment_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 60 --statsd ${STATSD_HOST:-graphite}
     deploy:

--- a/test/deploy-play.yaml
+++ b/test/deploy-play.yaml
@@ -1,0 +1,27 @@
+- name: Deploy Nuvla
+  hosts: master
+  remote_user: root
+  vars:
+    deploy_dest: /tmp/nuvla-test
+    stack_name: test
+  tasks:
+
+  - name: copy scripts and configs
+    copy:
+      src: "{{ item }}"
+      dest: "{{ deploy_dest }}"
+    with_items:
+      - traefik
+      - docker-compose.yml
+    tags:
+      - files
+
+  - name: "Deploy Nuvla {{ stack_name }} stack on remote"
+    shell: |
+      export STATSD_HOST="{{ ansible_default_ipv4.address }}"
+      docker stack deploy --compose-file docker-compose.yml {{ stack_name }}
+    args:
+      chdir: "{{ deploy_dest }}"
+    tags:
+      - deploy
+

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -94,7 +94,7 @@ services:
       - test-net
 
   job-executor:
-    image: nuvladev/job:master
+    image: nuvladev/job:scheduling-depl-state
     entrypoint: /app/job_executor.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --es-hosts es
     deploy:
@@ -105,7 +105,7 @@ services:
       - test-net
 
   jobd-jobs-cleanup:
-    image: nuvladev/job:master
+    image: nuvladev/job:scheduling-depl-state
     entrypoint: /app/job_distributor_jobs_cleanup.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181
     deploy:
@@ -115,10 +115,21 @@ services:
     networks:
       - test-net
 
-  jobd-deployment-state:
-    image: nuvladev/job:master
+  jobd-deployment-state_10:
+    image: nuvladev/job:scheduling-depl-state
     entrypoint: /app/job_distributor_deployment_state.py
-    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 10
+    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 10 --statsd ${STATSD_HOST:-graphite}
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+    networks:
+      - test-net
+
+  jobd-deployment-state_60:
+    image: nuvladev/job:scheduling-depl-state
+    entrypoint: /app/job_distributor_deployment_state.py
+    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 60 --statsd ${STATSD_HOST:-graphite}
     deploy:
       restart_policy:
         condition: on-failure
@@ -127,7 +138,7 @@ services:
       - test-net
 
   jobd-comp-image-state:
-    image: nuvladev/job:master
+    image: nuvladev/job:scheduling-depl-state
     entrypoint: /app/job_distributor_component_image_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600
     deploy:
@@ -138,7 +149,7 @@ services:
       - test-net
 
   jobd-srvc-image-state:
-    image: nuvladev/job:master
+    image: nuvladev/job:scheduling-depl-state
     entrypoint: /app/job_distributor_service_image_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600
     deploy:
@@ -149,7 +160,7 @@ services:
       - test-net
 
   jobd-nuvlabox-releases:
-    image: nuvladev/job:master
+    image: nuvladev/job:scheduling-depl-state
     entrypoint: /app/job_distributor_nuvlabox_releases.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181
     deploy:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -105,7 +105,7 @@ services:
       - test-net
 
   jobd-jobs-cleanup:
-    image: nuvladev/job:scheduling-depl-state
+    image: nuvladev/job:master
     entrypoint: /app/job_distributor_jobs_cleanup.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181
     deploy:
@@ -116,9 +116,9 @@ services:
       - test-net
 
   jobd-deployment-state_10:
-    image: nuvladev/job:scheduling-depl-state
+    image: nuvladev/job:master
     entrypoint: /app/job_distributor_deployment_state.py
-    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 10 --statsd ${STATSD_HOST:-graphite}
+    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 10
     deploy:
       restart_policy:
         condition: on-failure
@@ -127,9 +127,9 @@ services:
       - test-net
 
   jobd-deployment-state_60:
-    image: nuvladev/job:scheduling-depl-state
+    image: nuvladev/job:master
     entrypoint: /app/job_distributor_deployment_state.py
-    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 60 --statsd ${STATSD_HOST:-graphite}
+    command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 60
     deploy:
       restart_policy:
         condition: on-failure
@@ -138,7 +138,7 @@ services:
       - test-net
 
   jobd-comp-image-state:
-    image: nuvladev/job:scheduling-depl-state
+    image: nuvladev/job:master
     entrypoint: /app/job_distributor_component_image_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600
     deploy:
@@ -149,7 +149,7 @@ services:
       - test-net
 
   jobd-srvc-image-state:
-    image: nuvladev/job:scheduling-depl-state
+    image: nuvladev/job:master
     entrypoint: /app/job_distributor_service_image_state.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181 --interval 3600
     deploy:
@@ -160,7 +160,7 @@ services:
       - test-net
 
   jobd-nuvlabox-releases:
-    image: nuvladev/job:scheduling-depl-state
+    image: nuvladev/job:master
     entrypoint: /app/job_distributor_nuvlabox_releases.py
     command: --api-url http://api:8200 --api-authn-header group/nuvla-admin --zk-hosts zk:2181
     deploy:


### PR DESCRIPTION
Two deployment schedulers with different intervals for deployment state check: one `_10` to check each 10 sec for the first 2 min after the start of the deployment and each 60 sec after that `_60`.

Depends on https://github.com/nuvla/job-engine/pull/110