### PR TITLE
kafka-notify new release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
   - Add Elasticsearch sniffer and Kafka init env vars to compose files.
   - Add Data Records related BlackBox creation notifications via ksqldb.
+  - [nuvla/kafka-notify:0.6.0](https://github.com/nuvla/kafka-notify/blob/main/CHANGELOG.md)
 
 ### Changed
 

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -231,7 +231,7 @@ services:
 
   # Notification service to Slack
   notify-slack:
-    image: nuvla/kafka-notify:0.5.0
+    image: nuvla/kafka-notify:0.6.0
     networks:
       - backend
     command:
@@ -241,7 +241,7 @@ services:
 
   # Notification service to Email
   notify-email:
-    image: nuvla/kafka-notify:0.5.0
+    image: nuvla/kafka-notify:0.6.0
     networks:
       - backend
     command:

--- a/prod/core/docker-compose.yml
+++ b/prod/core/docker-compose.yml
@@ -105,7 +105,7 @@ services:
       - nuvla-backend
 
   notify-slack:
-    image: nuvla/kafka-notify:0.5.0
+    image: nuvla/kafka-notify:0.6.0
     deploy:
       placement:
         constraints:
@@ -121,7 +121,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: "${KAFKA_BOOTSTRAP_SERVERS:-kafka:9092}"
 
   notify-email:
-    image: nuvla/kafka-notify:0.5.0
+    image: nuvla/kafka-notify:0.6.0
     deploy:
       placement:
         constraints:


### PR DESCRIPTION
kafka-notify new release 0.6.0. See 
https://hub.docker.com/layers/nuvla/kafka-notify/0.6.0/images/sha256-c5e207d50d8c57b1c225cfe8d232ee68f3265e80494d5072bb83aea4c4028474?context=repo